### PR TITLE
Fix Linux build problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
+all: openssl heartleech
 
+openssl:
+	if [ ! -d openssl ] ; then git clone git://git.openssl.org/openssl.git && cd openssl && git checkout bb3e20cf8c5e733c16fe68ce41f67eea5a2a520e && ./config && make && make depend ; fi
 
 heartleech: heartleech.c
-	gcc -I../openssl/include -L../openssl -lcrypto -lssl -lcrypto -ldl -lpthread -o heartleech heartleech.c
+	gcc heartleech.c -Iopenssl -Iopenssl/include -Iopenssl/crypto/include -Iopenssl/ssl openssl/libssl.a openssl/libcrypto.a -ldl -lpthread -o heartleech
 
-
+clean:
+	-rm -r heartleech openssl

--- a/heartleech.c
+++ b/heartleech.c
@@ -75,8 +75,9 @@ typedef uintptr_t pthread_t;
 #include <errno.h>
 #include <dlfcn.h>
 #include <pthread.h>
+#include "./openssl/crypto/bn/bn_lcl.h"
+#include "./openssl/ssl/ssl_locl.h"
 #define WSAGetLastError() (errno)
-#define closesocket(fd) close(fd)
 #define WSA(err) (err)
 #endif
 #if defined(_MSC_VER)


### PR DESCRIPTION
- Adds 2 missing headers needed for compiling
- Removes a definition already defined earlier (not necessary)
- Fixes problems with incorrect gcc options
- Automatically download and build the correct version of openssl
- Add possibility for cleaning the build environment